### PR TITLE
Fix resourceTransitGatewayVPCAttachmentUpdate

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,42 +1,44 @@
+# Visit https://goreleaser.com for documentation on how to customize this
+# behavior.
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-  - env:
-      # goreleaser does not work with CGO, it could also complicate
-      # usage by users in CI/CD systems like Terraform Cloud where
-      # they are unable to install libraries.
-      - CGO_ENABLED=0
-    mod_timestamp: '{{ .CommitTimestamp }}'
-    flags:
-      - -trimpath
-    ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
-    goos:
-      - freebsd
-      - windows
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - '386'
-      - arm
-      - arm64
-    ignore:
-      - goos: darwin
-        goarch: '386'
-    binary: '{{ .ProjectName }}_v{{ .Version }}'
+- env:
+    # goreleaser does not work with CGO, it could also complicate
+    # usage by users in CI/CD systems like Terraform Cloud where
+    # they are unable to install libraries.
+    - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
+  ldflags:
+    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+  goos:
+    - freebsd
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - '386'
+    - arm
+    - arm64
+  ignore:
+    - goos: darwin
+      goarch: '386'
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-  - format: zip
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 signs:
   - artifacts: checksum
     args:
-      # if you are using this is a GitHub action or some other automated pipeline, you
+      # if you are using this in a GitHub action or some other automated pipeline, you 
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"
@@ -46,7 +48,7 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
-  # Visit your project's GitHub Releases page to publish this release.
-  draft: true
+  # If you want to manually examine the release before its live, uncomment this line:
+  # draft: true
 changelog:
   skip: true

--- a/aiven/resource_transit_gateway_vpc_attachement.go
+++ b/aiven/resource_transit_gateway_vpc_attachement.go
@@ -132,6 +132,10 @@ func resourceTransitGatewayVPCAttachmentUpdate(ctx context.Context, d *schema.Re
 		}
 	}
 
+	if len(add) == 0 && len(deleteCIDRs) == 0 {
+		return resourceVPCPeeringConnectionRead(ctx, d, m)
+	}
+
 	_, err = client.TransitGatewayVPCAttachment.Update(projectName, vpcID, aiven.TransitGatewayVPCAttachmentRequest{
 		Add:    add,
 		Delete: deleteCIDRs,

--- a/aiven/resource_transit_gateway_vpc_attachement.go
+++ b/aiven/resource_transit_gateway_vpc_attachement.go
@@ -91,7 +91,7 @@ func resourceTransitGatewayVPCAttachmentUpdate(ctx context.Context, d *schema.Re
 	}
 
 	// prepare a list of new transit gateway vpc attachment that needs to be added
-	var add []aiven.TransitGatewayVPCAttachment
+	add := []aiven.TransitGatewayVPCAttachment{}
 	for _, fresh := range cidrs {
 		var isNew = true
 
@@ -103,17 +103,21 @@ func resourceTransitGatewayVPCAttachmentUpdate(ctx context.Context, d *schema.Re
 		}
 
 		if isNew {
+			var peerResourceGroup *string
+			if len(peeringConnection.PeerResourceGroup) > 0 {
+				peerResourceGroup = aiven.ToStringPointer(peeringConnection.PeerResourceGroup)
+			}
 			add = append(add, aiven.TransitGatewayVPCAttachment{
 				CIDR:              fresh,
 				PeerCloudAccount:  peerCloudAccount,
-				PeerResourceGroup: peeringConnection.PeerResourceGroup,
+				PeerResourceGroup: peerResourceGroup,
 				PeerVPC:           peerVPC,
 			})
 		}
 	}
 
 	// prepare a list of old cirds for deletion
-	var deleteCIDRs []string
+	deleteCIDRs := []string{}
 	for _, old := range peeringConnection.UserPeerNetworkCIDRs {
 		var forDeletion = true
 

--- a/go.mod
+++ b/go.mod
@@ -41,3 +41,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+replace github.com/aiven/aiven-go-client => github.com/antomatic/aiven-go-client v1.6.3-0.20211104081958-eacfdccb472e

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/aiven/aiven-go-client v1.6.3-0.20211021073338-26eab2e79cb4 h1:g9v9dDEFHVrOhFRF0QOApmGZTcMJ9qmJ6NFaMw6M5V4=
-github.com/aiven/aiven-go-client v1.6.3-0.20211021073338-26eab2e79cb4/go.mod h1:3+OtpccynSr5xvSGfn96jVM9dBUAr52HXlaZJi/Mz5o=
 github.com/andybalholm/crlf v0.0.0-20171020200849-670099aa064f/go.mod h1:k8feO4+kXDxro6ErPXBRTJ/ro2mf0SsFG8s7doP9kJE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/aiven/aiven-go-client v1.6.3-0.20211021073338-26eab2e79cb4/go.mod h1:
 github.com/andybalholm/crlf v0.0.0-20171020200849-670099aa064f/go.mod h1:k8feO4+kXDxro6ErPXBRTJ/ro2mf0SsFG8s7doP9kJE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/antomatic/aiven-go-client v1.6.3-0.20211104081958-eacfdccb472e h1:acP9Gk3n5WQ1YkFqXCXy3luKY3Ua2JW8FBe0ipT2DgI=
+github.com/antomatic/aiven-go-client v1.6.3-0.20211104081958-eacfdccb472e/go.mod h1:3+OtpccynSr5xvSGfn96jVM9dBUAr52HXlaZJi/Mz5o=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=


### PR DESCRIPTION
Fixes `aiven_transit_gateway_vpc_attachment` update operation.

I'm not creating the PR to the upstream, because it uses overridden `aiven-go-client` version. This PR is just for presenting a fix.

- initialize `add` and `deleteCIDRs` slices to make sure https://github.com/aiven/aiven-go-client renders valid JSON
- Fixes `peer_resource_group` empty value issue (see https://github.com/aiven/aiven-go-client/pull/143)
- Don't call `TransitGatewayVPCAttachment.Update` if both `add` and `deleteCIDRs` are empty

Related issue: https://github.com/aiven/terraform-provider-aiven/issues/607